### PR TITLE
Add multiple outputs for `-client` and `-server`, maintainer collective

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @blink1073 @fcollonval
+* @blink1073 @conda-forge/jupyter_server @fcollonval

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--jupyter-green.svg)](https://anaconda.org/conda-forge/pytest-jupyter) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-jupyter.svg)](https://anaconda.org/conda-forge/pytest-jupyter) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-jupyter.svg)](https://anaconda.org/conda-forge/pytest-jupyter) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-jupyter.svg)](https://anaconda.org/conda-forge/pytest-jupyter) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--jupyter--with--client-green.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-client) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-jupyter-with-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-client) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-jupyter-with-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-client) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-jupyter-with-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-client) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--jupyter--with--server-green.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-server) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-jupyter-with-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-server) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-jupyter-with-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-server) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-jupyter-with-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-server) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--jupyter--client-green.svg)](https://anaconda.org/conda-forge/pytest-jupyter-client) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-jupyter-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-client) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-jupyter-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-client) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-jupyter-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-client) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--jupyter--server-green.svg)](https://anaconda.org/conda-forge/pytest-jupyter-server) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-jupyter-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-server) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-jupyter-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-server) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-jupyter-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-server) |
 
 Installing pytest-jupyter
 =========================
@@ -43,16 +43,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pytest-jupyter, pytest-jupyter-with-client, pytest-jupyter-with-server` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `pytest-jupyter, pytest-jupyter-client, pytest-jupyter-server` can be installed with `conda`:
 
 ```
-conda install pytest-jupyter pytest-jupyter-with-client pytest-jupyter-with-server
+conda install pytest-jupyter pytest-jupyter-client pytest-jupyter-server
 ```
 
 or with `mamba`:
 
 ```
-mamba install pytest-jupyter pytest-jupyter-with-client pytest-jupyter-with-server
+mamba install pytest-jupyter pytest-jupyter-client pytest-jupyter-server
 ```
 
 It is possible to list all of the versions of `pytest-jupyter` available on your platform with `conda`:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About pytest-jupyter
 ====================
 
-Home: https://pypi.org/project/pytest-jupyter/
+Home: https://pypi.org/project/pytest-jupyter
 
 Package license: BSD-3-Clause
 
@@ -30,6 +30,8 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--jupyter-green.svg)](https://anaconda.org/conda-forge/pytest-jupyter) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-jupyter.svg)](https://anaconda.org/conda-forge/pytest-jupyter) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-jupyter.svg)](https://anaconda.org/conda-forge/pytest-jupyter) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-jupyter.svg)](https://anaconda.org/conda-forge/pytest-jupyter) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--jupyter--with--client-green.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-client) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-jupyter-with-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-client) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-jupyter-with-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-client) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-jupyter-with-client.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-client) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pytest--jupyter--with--server-green.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-server) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/pytest-jupyter-with-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-server) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pytest-jupyter-with-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-server) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/pytest-jupyter-with-server.svg)](https://anaconda.org/conda-forge/pytest-jupyter-with-server) |
 
 Installing pytest-jupyter
 =========================
@@ -41,16 +43,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `pytest-jupyter` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `pytest-jupyter, pytest-jupyter-with-client, pytest-jupyter-with-server` can be installed with `conda`:
 
 ```
-conda install pytest-jupyter
+conda install pytest-jupyter pytest-jupyter-with-client pytest-jupyter-with-server
 ```
 
 or with `mamba`:
 
 ```
-mamba install pytest-jupyter
+mamba install pytest-jupyter pytest-jupyter-with-client pytest-jupyter-with-server
 ```
 
 It is possible to list all of the versions of `pytest-jupyter` available on your platform with `conda`:
@@ -146,5 +148,6 @@ Feedstock Maintainers
 =====================
 
 * [@blink1073](https://github.com/blink1073/)
+* [@conda-forge/jupyter_server](https://github.com/conda-forge/jupyter_server/)
 * [@fcollonval](https://github.com/fcollonval/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
       requires:
         - pip
 
-  - name: pytest-jupyter-with-client
+  - name: pytest-jupyter-client
     build:
       noarch: python
     requirements:
@@ -77,14 +77,14 @@ outputs:
       license: BSD-3-Clause
       license_file: LICENSE
 
-  - name: pytest-jupyter-with-server
+  - name: pytest-jupyter-server
     build:
       noarch: python
     requirements:
       host:
         - python >=3.7
       run:
-        - {{ pin_subpackage("pytest-jupyter-with-client", max_pin="x.x.x") }}
+        - {{ pin_subpackage("pytest-jupyter-client", max_pin="x.x.x") }}
         - jupyter_server
         - python >=3.7
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -23,7 +23,6 @@ outputs:
     build:
       noarch: python
       script: {{ PYTHON }} -m pip install . -vv
-      number: 0
     requirements:
       host:
         - python >=3.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,11 @@
-{% set name = "pytest-jupyter" %}
 {% set version = "0.5.3" %}
 
 package:
-  name: {{ name|lower }}
+  name: pytest-jupyter-split
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest_jupyter-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/pytest-jupyter/pytest_jupyter-{{ version }}.tar.gz
   sha256: bc3539ee343cf7bd2de94a3dbadc214bddeac509899ca188112d4cb7f230f5f9
 
 build:
@@ -17,37 +16,106 @@ build:
 requirements:
   host:
     - python >=3.7
-    - pip
-    - hatchling
   run:
     - python >=3.7
-    - jupyter_core
-    - pytest
 
-test:
-  source_files:
-    - tests
-  imports:
-    - pytest_jupyter
-  commands:
-    - pip check
-    - cd tests && pytest -vv --cov pytest_jupyter --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 90
-  requires:
-    - pip
-    - pytest-cov
-    - jupyter_server >=1.21
-    - jupyter_client >=7.4
-    - ipykernel >=6.14
-    - nbformat >=5.3
+outputs:
+  - name: pytest-jupyter
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . -vv
+      number: 0
+    requirements:
+      host:
+        - python >=3.7
+        - pip
+        - hatchling
+      run:
+        - python >=3.7
+        - jupyter_core
+        - pytest
+      run_constrained:
+        # the hard `run` dependencies are in sub-packages
+        - jupyter_server >=1.21
+        - jupyter_client >=7.4
+        - ipykernel >=6.14
+        - nbformat >=5.3
+    test:
+      source_files:
+        - tests
+      imports:
+        - pytest_jupyter
+        - pytest_jupyter.jupyter_core
+      commands:
+        - pip check
+      requires:
+        - pip
+
+  - name: pytest-jupyter-with-client
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage("pytest-jupyter", max_pin="x.x.x") }}
+        - ipykernel
+        - jupyter_client
+        - python >=3.7
+    test:
+      imports:
+        - pytest_jupyter
+        - pytest_jupyter.jupyter_client
+      commands:
+        - pip check
+      requires:
+        - pip
+    about:
+      home: https://pypi.org/project/pytest-jupyter
+      summary: A pytest plugin for testing Jupyter libraries and extensions. (with client dependencies)
+      dev_url: https://github.com/jupyter-server/pytest-jupyter
+      license: BSD-3-Clause
+      license_file: LICENSE
+
+  - name: pytest-jupyter-with-server
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.7
+      run:
+        - {{ pin_subpackage("pytest-jupyter-with-client", max_pin="x.x.x") }}
+        - jupyter_server
+        - python >=3.7
+    test:
+      source_files:
+        - tests
+      imports:
+        - pytest_jupyter
+        - pytest_jupyter.jupyter_server
+      commands:
+        - pip check
+        - cd tests && pytest -vv --cov=pytest_jupyter --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=90
+      requires:
+        - pip
+        - pytest-cov
+    about:
+      home: https://pypi.org/project/pytest-jupyter
+      summary: A pytest plugin for testing Jupyter libraries and extensions. (with server dependencies)
+      dev_url: https://github.com/jupyter-server/pytest-jupyter
+      license: BSD-3-Clause
+      license_file: LICENSE
 
 about:
-  home: https://pypi.org/project/pytest-jupyter/
+  home: https://pypi.org/project/pytest-jupyter
   summary: A pytest plugin for testing Jupyter libraries and extensions.
   dev_url: https://github.com/jupyter-server/pytest-jupyter
   license: BSD-3-Clause
   license_file: LICENSE
 
 extra:
+  feedstock-name: pytest-jupyter
   recipe-maintainers:
     - blink1073
     - fcollonval
+    - conda-forge/jupyter_server


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- adds `pytest-jupyter-client` and `pytest-jupyter-server`
- adds @conda-forge/jupyter_server maintainer collective for more eyeballs
- removes some jinja vars